### PR TITLE
新規ユーザー作成後にMutationを１秒待機

### DIFF
--- a/functions/src/events/auth/auth.ts
+++ b/functions/src/events/auth/auth.ts
@@ -5,11 +5,8 @@ export const createNewUser = functions.auth.user().onCreate((user) => {
   const {uid, phoneNumber} = user;
   // phoneNumber should never be undefined if we only allow phone auth
   const account: User = {
-    uid,
+    uid: uid,
     phoneNumber: phoneNumber || "",
-    name: undefined,
-    age: undefined,
-    weight: undefined,
   };
   functions.logger.log("user created", account.uid, account.phoneNumber);
   return admin.firestore().collection("users").doc(uid).set(account);

--- a/functions/src/lib/sleep.ts
+++ b/functions/src/lib/sleep.ts
@@ -1,0 +1,8 @@
+export const sleep = (waitSec: number) => {
+  const time = waitSec * 1000;
+  return new Promise((resolve) => {
+    setTimeout(function() {
+      resolve(null);
+    }, time);
+  });
+};

--- a/functions/src/resolvers/updateUser.ts
+++ b/functions/src/resolvers/updateUser.ts
@@ -1,6 +1,8 @@
 import * as admin from "firebase-admin";
 import {validateFirebaseIdToken} from "../helpers";
 import {AuthenticationError, ExpressContext} from "apollo-server-express";
+import * as functions from "firebase-functions";
+import {sleep} from "../lib/sleep";
 
 export const updateUser = async (
     _: null,
@@ -21,14 +23,20 @@ export const updateUser = async (
 ):Promise<FirebaseFirestore.DocumentData | undefined> => {
   const reqUser = await validateFirebaseIdToken(context);
   if (uid === reqUser.uid) {
-    await admin.firestore().collection("users").doc(uid).set({
-      name,
-      age,
-      weight,
-    });
-    const userRef = await admin.firestore().doc(`users/${uid}`).get();
-    const user = await userRef.data();
-    return user;
+    try {
+      await sleep(1);
+      await admin.firestore().collection("users").doc(uid).update({
+        name: name,
+        age: age,
+        weight: weight,
+      });
+      const userRef = await admin.firestore().doc(`users/${uid}`).get();
+      const user = await userRef.data();
+      return user;
+    } catch (e) {
+      functions.logger.log(e);
+      throw new Error;
+    }
   } else {
     throw new AuthenticationError("unauthorized");
   }


### PR DESCRIPTION


Firebaseでは同ドキュメントへの書き込みを1秒につき１回に制限している。
https://firebase.google.com/docs/firestore/best-practices?hl=ja

これにより、新規ユーザー登録が正常に行えない不具合があったため、明示的に１秒待つようにした